### PR TITLE
stop error when no songs match search criteria

### DIFF
--- a/db-api/db-scripts/song.ts
+++ b/db-api/db-scripts/song.ts
@@ -69,7 +69,7 @@ export class SongDb {
             this.getMatchPipeline(params),
             {'$count': 'song_count'}
         ]).toArray();
-        return count_object[0].song_count
+        return count_object.length > 0 ? count_object[0].song_count : 0
     }
 
     public async findSong(details: string) {


### PR DESCRIPTION
Previously the db-api would crash when there were no songs matching the search criteria. This fixes that.