### PR TITLE
add option to copy chart songs

### DIFF
--- a/ui/src/app/chart-display/chart-display.component.html
+++ b/ui/src/app/chart-display/chart-display.component.html
@@ -4,6 +4,7 @@
         <div class="dropdown-content">
             <div class="dropdown-option" (click)="copyPlaintext()">Copy Plaintext Chart</div>
             <div class="dropdown-option" (click)="copyBBCode()">Copy BBCode Chart</div>
+            <div class="dropdown-option" (click)="copyChartSongs()">Copy Chart Songs</div>
         </div>
     </div>
     <a routerLink="./edit" title="Edit Details"><fa-icon [icon]="faPenSquare" class="fa-lg"></fa-icon></a>

--- a/ui/src/app/chart-display/chart-display.component.ts
+++ b/ui/src/app/chart-display/chart-display.component.ts
@@ -101,6 +101,15 @@ export class ChartDisplayComponent implements OnInit {
     this.clipboardService.copyFromContent(chartString)
   }
 
+  public copyChartSongs() {
+    let chartString = ""
+    for (const song of this.chartData) {
+      chartString += `${song.artistDisplay} - ${song.title}\n`
+    }
+    this.clipboardService.copyFromContent(chartString)
+  }
+
+
   public copyBBCode() {
     this.chartService.getChartString(this.seriesName, this.chartName).subscribe((chartString: string) => 
       this.clipboardService.copyFromContent(chartString)


### PR DESCRIPTION
Add an option to copy the songs of a chart alongside the BBCode / Plaintext options.
![image](https://github.com/user-attachments/assets/ccaba29d-5bd4-42eb-af95-ba229af3020d)
