### PR TITLE
Remove deprecated RouterTestingModule

### DIFF
--- a/ui/src/app/app.component.spec.ts
+++ b/ui/src/app/app.component.spec.ts
@@ -1,7 +1,6 @@
 import { Component } from '@angular/core';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { Routes } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter, Routes } from '@angular/router';
 import { AppComponent } from './app.component';
 
 @Component({
@@ -42,7 +41,8 @@ export const routes: Routes = [
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-    imports: [RouterTestingModule.withRoutes(routes), TestSeriesSelectComponent, AppComponent],
+    imports: [TestSeriesSelectComponent, AppComponent],
+    providers: [provideRouter(routes)],
 }).compileComponents();
   });
 

--- a/ui/src/app/artist-display/artist-display.component.spec.ts
+++ b/ui/src/app/artist-display/artist-display.component.spec.ts
@@ -1,8 +1,8 @@
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from "@angular/router/testing";
 import { ArtistDisplayComponent } from './artist-display.component';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
 
 
 describe('ArtistDisplayComponent', () => {
@@ -11,8 +11,12 @@ describe('ArtistDisplayComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-    imports: [RouterTestingModule, ArtistDisplayComponent],
-    providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
+    imports: [ArtistDisplayComponent],
+    providers: [
+      provideHttpClient(withInterceptorsFromDi()), 
+      provideHttpClientTesting(), 
+      provideRouter([])
+    ]
 })
     .compileComponents();
   });

--- a/ui/src/app/artist/artist.component.spec.ts
+++ b/ui/src/app/artist/artist.component.spec.ts
@@ -1,6 +1,5 @@
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from "@angular/router/testing";
 import { ArtistComponent } from './artist.component';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 
@@ -11,7 +10,7 @@ describe('ArtistComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-    imports: [RouterTestingModule, ArtistComponent],
+    imports: [ArtistComponent],
     providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
 })
     .compileComponents();

--- a/ui/src/app/chart-edit/chart-edit.component.spec.ts
+++ b/ui/src/app/chart-edit/chart-edit.component.spec.ts
@@ -1,9 +1,9 @@
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from "@angular/router/testing";
 import { ChartEditComponent } from './chart-edit.component';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { MatNativeDateModule } from '@angular/material/core';
+import { provideRouter } from '@angular/router';
 
 
 describe('ChartEditComponent', () => {
@@ -12,8 +12,12 @@ describe('ChartEditComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-    imports: [RouterTestingModule, ChartEditComponent, MatNativeDateModule],
-    providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
+    imports: [ChartEditComponent, MatNativeDateModule],
+    providers: [
+      provideHttpClient(withInterceptorsFromDi()), 
+      provideHttpClientTesting(),
+      provideRouter([])
+    ]
 })
     .compileComponents();
   });

--- a/ui/src/app/chart-select/chart-select.component.spec.ts
+++ b/ui/src/app/chart-select/chart-select.component.spec.ts
@@ -1,8 +1,8 @@
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from "@angular/router/testing";
 import { ChartSelectComponent } from './chart-select.component';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
 
 
 describe('ChartSelectComponent', () => {
@@ -11,8 +11,12 @@ describe('ChartSelectComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-    imports: [RouterTestingModule, ChartSelectComponent],
-    providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
+    imports: [ChartSelectComponent],
+    providers: [
+      provideHttpClient(withInterceptorsFromDi()), 
+      provideHttpClientTesting(),
+      provideRouter([])
+    ]
 })
     .compileComponents();
   });
@@ -27,3 +31,4 @@ describe('ChartSelectComponent', () => {
     expect(component).toBeTruthy();
   });
 });
+

--- a/ui/src/app/create-chart-basic/create-chart-basic.component.spec.ts
+++ b/ui/src/app/create-chart-basic/create-chart-basic.component.spec.ts
@@ -1,6 +1,5 @@
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 
 import { CreateBasicChartComponent } from './create-chart-basic.component';
 import { of } from 'rxjs';
@@ -20,7 +19,7 @@ describe('CreateBasicChartComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-    imports: [RouterTestingModule, CreateBasicChartComponent, MatNativeDateModule],
+    imports: [CreateBasicChartComponent, MatNativeDateModule],
     providers: [
         { provide: ActivatedRoute, useValue: mockActivatedRoute },
         provideHttpClient(withInterceptorsFromDi()),

--- a/ui/src/app/modals/delete-series/delete-item.component.spec.ts
+++ b/ui/src/app/modals/delete-series/delete-item.component.spec.ts
@@ -1,6 +1,5 @@
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from "@angular/router/testing";
 import { DeleteItemComponent } from './delete-item.component';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 
@@ -11,7 +10,7 @@ describe('DeleteItemComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-    imports: [RouterTestingModule, DeleteItemComponent],
+    imports: [DeleteItemComponent],
     providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
 })
     .compileComponents();

--- a/ui/src/app/modals/mark-duplicate/mark-duplicate.component.spec.ts
+++ b/ui/src/app/modals/mark-duplicate/mark-duplicate.component.spec.ts
@@ -1,6 +1,5 @@
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from "@angular/router/testing";
 import { MarkDuplicateComponent } from './mark-duplicate.component';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 
@@ -11,7 +10,7 @@ describe('MarkDuplicateComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-    imports: [RouterTestingModule, MarkDuplicateComponent],
+    imports: [MarkDuplicateComponent],
     providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
 })
     .compileComponents();

--- a/ui/src/app/modals/new-songs/new-songs.component.spec.ts
+++ b/ui/src/app/modals/new-songs/new-songs.component.spec.ts
@@ -1,6 +1,5 @@
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from "@angular/router/testing";
 import { NewSongsComponent } from './new-songs.component';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 
@@ -11,7 +10,7 @@ describe('NewSongsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-    imports: [RouterTestingModule, NewSongsComponent],
+    imports: [NewSongsComponent],
     providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
 })
     .compileComponents();

--- a/ui/src/app/series-select/series-select.component.spec.ts
+++ b/ui/src/app/series-select/series-select.component.spec.ts
@@ -1,8 +1,7 @@
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { Component } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { Router, Routes } from '@angular/router';
-import { RouterTestingModule } from "@angular/router/testing";
+import { provideRouter, Router, Routes } from '@angular/router';
 import { of } from 'rxjs';
 import { ChartService } from '../services/chart.service';
 
@@ -39,8 +38,13 @@ describe('SeriesSelectComponent', () => {
     }
     
     await TestBed.configureTestingModule({
-    imports: [RouterTestingModule.withRoutes(routes), SeriesSelectComponent, MockCreateSeriesComponent],
-    providers: [{ provide: ChartService, useValue: mockChartService }, provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
+    imports: [SeriesSelectComponent, MockCreateSeriesComponent],
+    providers: [
+      { provide: ChartService, useValue: mockChartService }, 
+      provideHttpClient(withInterceptorsFromDi()), 
+      provideHttpClientTesting(),
+      provideRouter(routes)
+    ]
     }).overrideComponent(SeriesSelectComponent, {
       remove: { imports: [ CreateSeriesComponent ] },
       add: { imports: [ MockCreateSeriesComponent ] }

--- a/ui/src/app/song-display/song-display.component.spec.ts
+++ b/ui/src/app/song-display/song-display.component.spec.ts
@@ -1,9 +1,9 @@
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 
 import { SongDisplayComponent } from './song-display.component';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
 
 describe('SongDisplayComponent', () => {
   let component: SongDisplayComponent;
@@ -11,8 +11,12 @@ describe('SongDisplayComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-    imports: [RouterTestingModule, SongDisplayComponent],
-    providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
+    imports: [SongDisplayComponent],
+    providers: [
+      provideHttpClient(withInterceptorsFromDi()),
+      provideHttpClientTesting(),
+      provideRouter([])
+    ]
 })
     .compileComponents();
   });

--- a/ui/src/app/totals/totals.component.spec.ts
+++ b/ui/src/app/totals/totals.component.spec.ts
@@ -1,6 +1,5 @@
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { TotalsComponent } from './totals.component';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import {MatNativeDateModule} from '@angular/material/core';
@@ -12,7 +11,7 @@ describe('TotalsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-    imports: [RouterTestingModule, TotalsComponent, MatNativeDateModule],
+    imports: [TotalsComponent, MatNativeDateModule],
     providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
 })
     .compileComponents();


### PR DESCRIPTION
Removes RouterTestingModule from each of the test files currently using it as it is deprecated. To verify, see that tests still pass.