### PR TITLE
fix re-entry and duplicate session issues in chart preview

### DIFF
--- a/db-api/db-scripts/chart.ts
+++ b/db-api/db-scripts/chart.ts
@@ -247,6 +247,7 @@ export class ChartDb {
                 const existingSong = await this.db.collection<Song>(SONG_COLLECTION).findOne({ $and: [{ artistDisplay }, { title }] })
                 if (existingSong) {
                     song._id = existingSong._id.toString()
+                    await this.updateChartWeek(song._id, seriesName, params.name, newChartPositions[0], sessionId)
                 } else {
                     const artistIds = await this.getArtistIds(song)
                     if (nextChart) {
@@ -498,7 +499,15 @@ export class ChartDb {
             { $match: { name: series } },
             { $unwind: "$charts" },
             { $replaceRoot: { newRoot: "$charts" } },
-            { $match: { name: chart } },
+            { $match: {
+                $and: [
+                    { name: chart },
+                    {$or: [
+                        {sessionId: {$exists: false}},
+                        {sessionId}
+                    ]}
+                ]}
+            },
         ]).toArray())
         const chartDate = chartDateArray[0].date
         console.log('get previous', JSON.stringify(chart));


### PR DESCRIPTION
1. There was an issue in which re-entries were omitted from the final chart if included in interactive sessions. This has been fixed.
2. Whilst fixing this, I found an issue in which the wrong session could be fetched if there were two charts with the correct name, making the statistics incorrect. This has also been fixed.